### PR TITLE
Downgrade to Minecraft 1.21.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# Build outputs
+output/
+local.properties
+
+# Swap files
+*.swp

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-    id 'dev.architectury.loom' version '1.10-SNAPSHOT' apply false
+    id 'dev.architectury.loom' version '1.7-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
 
 architectury {
-    minecraft = rootProject.minecraft_version
+    minecraft = project.minecraft_version
 }
 
 allprojects {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -8,28 +8,37 @@ architectury {
 }
 
 configurations {
-    common
-    shadowBundle
+    common {
+        canBeResolved = true
+        canBeConsumed = false
+    }
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
     developmentFabric.extendsFrom common
+
+    // Files in this configuration will be bundled into your mod using the Shadow plugin.
+    // Don't use the `shadow` configuration from the plugin itself as it's meant for excluding files.
+    shadowBundle {
+        canBeResolved = true
+        canBeConsumed = false
+    }
 }
 
 repositories {
     mavenCentral()
-    maven { url 'https://maven.fabricmc.net/' }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://maven.nucleoid.xyz/' }
 }
 
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
-    modApi "net.fabricmc.fabric-api:fabric-api:$rootProject.fabric_api_version+$rootProject.minecraft_version"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:$rootProject.fabric_api_version+$rootProject.minecraft_version"
+    include(modImplementation("me.lucko:fabric-permissions-api:0.3.1")) { transitive = false }
 
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 
-    modImplementation include("eu.pb4:placeholder-api:2.4.2+1.21")
+    modImplementation include("eu.pb4:placeholder-api:2.5.2+1.21.3")
 }
 
 processResources {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,6 +18,6 @@
   },
   "depends": {
     "fabricloader": ">=0.16.9",
-    "minecraft": ">=1.21.3"
+    "minecraft": ">=1.21"
   }
 }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -51,7 +51,7 @@ A Minecraft Forge and Fabric economy plugin that supports multiple currencies.
    # Does this dependency have to exist - if not, ordering below must be specified
    mandatory=true #mandatory
    # The version range of the dependency
-   versionRange="[53,)" #mandatory
+   versionRange="[52,)" #mandatory
    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
    ordering="NONE"
    # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -61,6 +61,6 @@ A Minecraft Forge and Fabric economy plugin that supports multiple currencies.
    modId="minecraft"
    mandatory=true
    # This version range declares a minimum of the current minecraft version up to but not including the next major version
-   versionRange="[1.21.3,1.21.4]"
+   versionRange="[1.21,1.22]"
    ordering="NONE"
    side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,14 @@ org.gradle.daemon=false
 
 enabled_platforms=fabric,neoforge,forge
 
-# Mod Properties
 archives_name=realeconomy
-mod_version=0.1.1
+mod_version=1.1.0
 maven_group=co.lemee
 
-# Fabric Properties
-minecraft_version=1.21.4
-yarnVersion=1.21.4+build.4
-fabric_loader_version=0.16.14
-fabric_api_version=0.119.2
+minecraft_version=1.21.1
 
-# Dependencies
-forge_version=54.1.3
-neoforge_version=21.4.136
+fabric_loader_version=0.16.9
+fabric_api_version=0.114.0
+
+forge_version=52.1.0
+neoforge_version=21.1.170

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -21,6 +21,6 @@ description="Create central bank, bank, currency and use it ingame"
 [[dependencies.realeconomy]]
     modId="minecraft"
     type="required"
-    versionRange="[1.21.3,1.21.5)"
+    versionRange="[1.21,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
## Summary

- Update minecraft_version from 1.21.4 to 1.21.1
- Update mod_version to 1.1.0
- Downgrade Architectury Loom from 1.10 to 1.7
- Downgrade Gradle from 8.12.1 to 8.10
- Update Fabric API to 0.114.0
- Update Forge version from 54.1.3 to 52.1.0
- Update NeoForge version from 21.4.136 to 21.1.170
- Update Placeholder API to 2.5.2+1.21.3
- Add fabric-permissions-api dependency for Fabric
- Update mod metadata version ranges for broader 1.21.x compatibility
- Add output/ to .gitignore

## Test plan

- [ ] Build successfully for all platforms (Fabric, Forge, NeoForge)
- [ ] Test mod loads correctly on MC 1.21.1
- [ ] Verify all commands work as expected